### PR TITLE
Fix build issue and sample session dictionary

### DIFF
--- a/src/config/sessions/sample.ini
+++ b/src/config/sessions/sample.ini
@@ -4,6 +4,7 @@ ReconnectInterval=60
 SocketAcceptPort=7091
 SenderCompID=AQUAQ
 TargetCompID=BROKER
+TargetSubID=ADMIN
 SocketNodelay=Y
 PersistMessage=Y
 FileStorePath=cache
@@ -40,4 +41,3 @@ SenderCompID=AQUAQ
 TargetCompID=BROKER
 FileStorePath=cache
 FileLogPath=log
-

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -58,8 +58,8 @@ class FixEngineApplication : public FIX::Application
 static void FillFromIterators(FIX::FieldMap::Fields::const_iterator begin, FIX::FieldMap::Fields::const_iterator end, K* keys, K* values)
 {
     for (auto it = begin; it != end; it++) {
-        J tag = (J) it->first;
-        auto str = it->second.getString().c_str();
+        J tag = (J) it->getTag();
+        auto str = it->getString().c_str();
 
         std::unordered_map<int, std::string>::const_iterator found = typemap.find(tag);
         ja(keys, &tag);


### PR DESCRIPTION
The fix adapter has not been able to build correctly due to incompatibility with QuickFix for over a year. A small change was needed to the main.cxx file to fix this.

The field TargetSubID now seems to be required to start up `acceptor` or `initiator`. This was added to the sample.ini file with the `Admin` value as default.